### PR TITLE
Fix misleading comment

### DIFF
--- a/lib/activejob/lockable.rb
+++ b/lib/activejob/lockable.rb
@@ -30,8 +30,7 @@ module ActiveJob
       end
     end
 
-    # Returns the current Redis connection. If none has been created, will
-    # create a new one.
+    # Returns the current Redis connection, raising an error if it hasn't been created
     def redis
       return @redis if @redis
       raise 'Redis is not configured'


### PR DESCRIPTION
Comment for `redis` method is misleading, it will not create a new Redis instance if it's missing, but rather raise an error