### PR TITLE
Avoid acquiring lock when already locked

### DIFF
--- a/lib/activejob/lockable/lockable.rb
+++ b/lib/activejob/lockable/lockable.rb
@@ -17,7 +17,7 @@ module ActiveJob
       def enqueue(options = {})
         @options = options
         if locked?
-          logger.info "job is locked, expires in #{locked_ttl} second"
+          logger.info "Job is locked, expires in #{locked_ttl} second(s)"
           send(on_locked_action) if on_locked_action && respond_to?(on_locked_action)
         else
           lock!
@@ -27,18 +27,25 @@ module ActiveJob
 
       def lock!
         return if lock_period.to_i <= 0
-        logger.info "locked with #{lock_key} for #{lock_period} seconds. Job_id: #{self.job_id} class_name: #{self.class}"
+        logger.info "Acquiring lock #{lock_extra_info}"
         begin
-          ActiveJob::Lockable::RedisStore.setex(lock_key, lock_period, self.job_id)
-        rescue => e
-          logger.info "EXCEPTION: locked with #{lock_key} for #{lock_period} seconds. Job_id: #{self.job_id} class_name: #{self.class}"
+          # `:ex => Fixnum`: Set the specified expire time, in seconds.
+          # `:nx => true`: Only set the key if it does not already exist.
+          lock_acquired = ActiveJob::Lockable::RedisStore.set(
+            lock_key,
+            self.job_id,
+            { ex: lock_period.to_i, nx: true }
+          )
+          raise "Could not acquire lock #{lock_extra_info}" unless lock_acquired
+        rescue StandardError => e
+          logger.info "EXCEPTION acquiring lock #{lock_extra_info}"
           raise e
         end
       end
 
       def unlock!
         return unless locked?
-        logger.info "unlocked with #{lock_key}. Job_id: #{self.job_id} class_name: #{self.class}"
+        logger.info "Releasing lock #{lock_extra_info}"
         ActiveJob::Lockable::RedisStore.del(lock_key)
       end
 
@@ -58,7 +65,11 @@ module ActiveJob
       private
 
       def lock_period
-        options[:lock]
+        options&.fetch(:lock, 0).to_i
+      end
+
+      def lock_extra_info
+        "[key #{lock_key}] [seconds #{lock_period.to_i}] [job_id #{self.job_id}] [class_name: #{self.class}]"
       end
     end
   end

--- a/lib/activejob/lockable/lockable.rb
+++ b/lib/activejob/lockable/lockable.rb
@@ -65,7 +65,9 @@ module ActiveJob
       private
 
       def lock_period
-        options&.fetch(:lock, 0).to_i
+        return 0 unless options
+
+        options[:lock].to_i
       end
 
       def lock_extra_info

--- a/lib/activejob/lockable/lockable.rb
+++ b/lib/activejob/lockable/lockable.rb
@@ -39,7 +39,7 @@ module ActiveJob
           raise "Could not acquire lock #{lock_extra_info}" unless lock_acquired
         rescue StandardError => e
           logger.info "EXCEPTION acquiring lock #{lock_extra_info}"
-          raise e
+          raise
         end
       end
 

--- a/lib/activejob/lockable/redis_store.rb
+++ b/lib/activejob/lockable/redis_store.rb
@@ -2,8 +2,8 @@ module ActiveJob
   module Lockable
     class RedisStore
       class << self
-        def setex(cache_key, expiration, cache_value)
-          ActiveJob::Lockable.redis.setex(cache_key, expiration, cache_value)
+        def set(cache_key, cache_value, options = {})
+          ActiveJob::Lockable.redis.set(cache_key, cache_value, options)
         end
 
         def exists?(cache_key)


### PR DESCRIPTION
The `setex` Redis command that we're using currently will, [as noted](https://github.com/redis/redis-rb/blob/5fd4e16ebc22b0abf1d52417fa960dac14b74b5f/lib/redis.rb#L819), _Set the time to live in seconds of a key_

It does not guarantee uniqueness of the key (in fact, if you call `setex` again on the same key, it will only update the TTL)

The proposed fix is to use the `set` [command](https://github.com/redis/redis-rb/blob/5fd4e16ebc22b0abf1d52417fa960dac14b74b5f/lib/redis.rb#L795), which by description _Set the string value of a key_, but when used with the options `:ex` and `:nx` give us the desired behaviour:

```
  #   - `:ex => Fixnum`: Set the specified expire time, in seconds.
  #   - `:nx => true`: Only set the key if it does not already exist.
```

Additionally, we will also check the return value of the `set` command. When it returns `false` it means a lock could not be acquired (already locked), and we can then raise an error in the `lock!` method