### PR TITLE
Ensure on_locked_action is called when a lock is not acquired

### DIFF
--- a/lib/activejob/lockable/lockable.rb
+++ b/lib/activejob/lockable/lockable.rb
@@ -66,7 +66,7 @@ module ActiveJob
 
       def trigger_on_locked_action
         logger.info "Job is locked, expires in #{locked_ttl} second(s)"
-        send(on_locked_action) if on_locked_action && respond_to?(on_locked_action)
+        public_send(on_locked_action) if on_locked_action && respond_to?(on_locked_action)
       end
 
       def lock_extra_info

--- a/lib/activejob/lockable/lockable.rb
+++ b/lib/activejob/lockable/lockable.rb
@@ -16,31 +16,25 @@ module ActiveJob
 
       def enqueue(options = {})
         @options = options
-        if locked?
-          logger.info "Job is locked, expires in #{locked_ttl} second(s)"
-          send(on_locked_action) if on_locked_action && respond_to?(on_locked_action)
-        else
-          lock!
-          super(options)
-        end
+        return trigger_on_locked_action unless lock!
+
+        super(options)
       end
 
       def lock!
-        return if lock_period.to_i <= 0
+        return true if lock_period.to_i <= 0
         logger.info "Acquiring lock #{lock_extra_info}"
-        begin
-          # `:ex => Fixnum`: Set the specified expire time, in seconds.
-          # `:nx => true`: Only set the key if it does not already exist.
-          lock_acquired = ActiveJob::Lockable::RedisStore.set(
-            lock_key,
-            self.job_id,
-            { ex: lock_period.to_i, nx: true }
-          )
-          raise "Could not acquire lock #{lock_extra_info}" unless lock_acquired
-        rescue StandardError => e
-          logger.info "EXCEPTION acquiring lock #{lock_extra_info}"
-          raise
-        end
+        # `:ex => Fixnum`: Set the specified expire time, in seconds.
+        # `:nx => true`: Only set the key if it does not already exist.
+        # Returns boolean, lock acquired or not
+        ActiveJob::Lockable::RedisStore.set(
+          lock_key,
+          self.job_id,
+          { ex: lock_period.to_i, nx: true }
+        )
+      rescue StandardError => e
+        logger.info "EXCEPTION acquiring lock #{lock_extra_info}"
+        raise
       end
 
       def unlock!
@@ -68,6 +62,11 @@ module ActiveJob
         return 0 unless options
 
         options[:lock].to_i
+      end
+
+      def trigger_on_locked_action
+        logger.info "Job is locked, expires in #{locked_ttl} second(s)"
+        send(on_locked_action) if on_locked_action && respond_to?(on_locked_action)
       end
 
       def lock_extra_info


### PR DESCRIPTION
The previous change on #3 fixed a race condition where a lock could be acquired more than once. When doing that, it started throwing exceptions when the lock could not be acquired, causing some noise.

It also did not fix the case where the `:on_locked_action` would not be called in that specific scenario - see #5 

This fix will ensure an exception is not thrown, and the `:on_locked_action` is properly called

Closes #5 