### PR TITLE
Compact arguments for default lock_key

### DIFF
--- a/lib/activejob/lockable/lockable.rb
+++ b/lib/activejob/lockable/lockable.rb
@@ -44,7 +44,7 @@ module ActiveJob
       end
 
       def lock_key
-        md5 = Digest::MD5.hexdigest(self.arguments.join)
+        md5 = Digest::MD5.hexdigest(self.arguments.compact.join)
         "#{self.class.name.downcase}:#{md5}"
       end
 

--- a/spec/activejob/lockable_spec.rb
+++ b/spec/activejob/lockable_spec.rb
@@ -169,6 +169,13 @@ RSpec.describe ActiveJob::Lockable, type: :job do
           .and_return(true)
         subject.set(lock: 2.seconds).perform_later(argument_id)
       end
+
+      it 'matches md5 of argument_id even with an added nil param' do
+        expect(ActiveJob::Lockable::RedisStore).to receive(:set)
+          .with(lock_key, String, { ex: 2, nx: true })
+          .and_return(true)
+        subject.set(lock: 2.seconds).perform_later(argument_id, nil)
+      end
     end
 
     context 'with overridden value' do


### PR DESCRIPTION
* Objective

This commit objective is about compacting the arguments while generating
the lock_key.

* Why

If nil agruments are added to the job execution it does change the MD5,
and it can cause a likely similar job to have a different lock_key and
bypass the locking.

* How

This commit compacts the arguments while generating the default
lock_key.